### PR TITLE
Make Scarlet Crate Fishable in the Cavern Layer

### DIFF
--- a/SkyblockThoriumHelperPlayer.cs
+++ b/SkyblockThoriumHelperPlayer.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+using Terraria.UI;
+
+
+namespace SkyblockThoriumHelper
+{
+    public class SkyblockThoriumHelperPlayer : ModPlayer
+    {
+        public override void CatchFish(Item fishingRod, Item bait, int power, int liquidType, int poolSize, int worldLayer, int questFish, ref int caughtType, ref bool junk)
+        {
+            Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
+            var player = Main.player[Main.myPlayer];
+
+            /*  8.9% if fishing power == 100
+                roughly matches other biome crates although 
+                it's techinically outside the regular fishing % 
+                so it's a bit wonky     */
+            float baseChance = .00089f; //* (player.cratePotion ? 2 : 1);
+            float scarletCrateChance = baseChance * power;
+            int crateChance = 10;
+
+            //Not really sure if this is an appropriate way to handle crate potions.
+            if (player.cratePotion)
+            {
+                crateChance /= 2;
+            }
+
+            //if in cavern or underworld and water and 1/CrateChance
+            if (worldLayer >= 3 && liquidType == 0 && Main.rand.NextFloat() < scarletCrateChance && Main.rand.Next(crateChance) == 0)
+            {
+                caughtType = thoriumMod.ItemType("ScarletCrate");
+            }
+        }
+    }
+}

--- a/SkyblockThoriumHelperPlayer.cs
+++ b/SkyblockThoriumHelperPlayer.cs
@@ -15,21 +15,25 @@ namespace SkyblockThoriumHelper
             Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
             var player = Main.player[Main.myPlayer];
 
-            /*  8.9% if fishing power == 100
-                roughly matches other biome crates although 
-                it's techinically outside the regular fishing % 
-                so it's a bit wonky     */
-            float baseChance = .00089f; //* (player.cratePotion ? 2 : 1);
+            /*  
+				8.9% if fishing power == 100
+                roughly matches other biome crates 
+			*/
+            float baseChance = .00089f; 
             float scarletCrateChance = baseChance * power;
             int crateChance = 10;
 
-            //Not really sure if this is an appropriate way to handle crate potions.
+            /*	
+				Change crate rate to 1/5 if player has a crate potion.
+				This doesn't behave the same really as other crates
+				but it's fairly close.	
+			*/
             if (player.cratePotion)
             {
                 crateChance /= 2;
             }
 
-            //if in cavern or underworld and water and 1/CrateChance
+            //if in cavern(3) or underworld and liquid is water and 1/CrateChance
             if (worldLayer >= 3 && liquidType == 0 && Main.rand.NextFloat() < scarletCrateChance && Main.rand.Next(crateChance) == 0)
             {
                 caughtType = thoriumMod.ItemType("ScarletCrate");

--- a/SkyblockThoriumHelperPlayer.cs
+++ b/SkyblockThoriumHelperPlayer.cs
@@ -1,41 +1,31 @@
 ﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.UI;
 
 
-namespace SkyblockThoriumHelper
-{
-    public class SkyblockThoriumHelperPlayer : ModPlayer
-    {
-        public override void CatchFish(Item fishingRod, Item bait, int power, int liquidType, int poolSize, int worldLayer, int questFish, ref int caughtType, ref bool junk)
-        {
+namespace SkyblockThoriumHelper {
+    public class SkyblockThoriumHelperPlayer : ModPlayer {
+        public override void CatchFish(Item fishingRod, Item bait, int power, int liquidType, int poolSize, int worldLayer, int questFish, ref int caughtType, ref bool junk) {
             Mod thoriumMod = ModLoader.GetMod("ThoriumMod");
-            var player = Main.player[Main.myPlayer];
 
-            /*  
-				8.9% if fishing power == 100
-                roughly matches other biome crates 
-			*/
+            /*  8.9% if fishing power == 100
+                roughly matches other biome crates */
             float baseChance = .00089f; 
             float scarletCrateChance = baseChance * power;
             int crateChance = 10;
 
-            /*	
-				Change crate rate to 1/5 if player has a crate potion.
-				This doesn't behave the same really as other crates
-				but it's fairly close.	
-			*/
-            if (player.cratePotion)
-            {
-                crateChance /= 2;
-            }
+            /*	Change crate rate to 1/5 if player has a crate potion.
+				This doesn't behave the same exactly as other crates
+				but it's fairly close. */
+            if (Main.player[Main.myPlayer].cratePotion) crateChance /= 2;
 
-            //if in cavern(3) or underworld and liquid is water and 1/CrateChance
-            if (worldLayer >= 3 && liquidType == 0 && Main.rand.NextFloat() < scarletCrateChance && Main.rand.Next(crateChance) == 0)
-            {
+            //Determine if Scarlet Crate should be fished
+            if (worldLayer >= 3 && liquidType == 0 
+                && Main.rand.NextFloat() < scarletCrateChance 
+                && Main.rand.Next(crateChance) == 0) {
+
                 caughtType = thoriumMod.ItemType("ScarletCrate");
             }
         }

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 author = Psyclonic
-version = 0.3.1
+version = 0.3.2
 displayName = SkyblockThoriumHelper
 modReferences = ThoriumMod
-buildIgnore = *.swp
+buildIgnore = *.swp, *.csproj,* .user, obj\*, bin\*, .vs\*
 homepage = https://forums.terraria.org/index.php?threads/skyblockthoriumhelper.75571/

--- a/description.txt
+++ b/description.txt
@@ -10,12 +10,16 @@ Recipes
 Drops
  - Magma Ore from Underworld enemies
  - Bag of Potential now gets more common as you defeat more vanilla pre-hardmode bosses
+ - Scarlet Crates can now be fished in water in the Cavern or Underworld Layer
 
 See the code at: https://github.com/Scowley4/SkyblockThoriumHelper
 Feedback welcome at https://forums.terraria.org/index.php?threads/skyblockthoriumhelper.75571/
 
 --------------------
 Version History
+
+v0.3.2
+ - Added fishable Scarlet Crates in water in Cavern or Underworld
 
 v0.3.1
  - Added recipes for Gold, Ice, Ivy, and Water Chests


### PR DESCRIPTION
Add fishing crate to Cavern and Underground Biomes normally they are not fishable until hardmode when the chest would be obtainable pre-hardmode.